### PR TITLE
Resolving bug in arccos calculation due to value out of range

### DIFF
--- a/pfh/pfh.py
+++ b/pfh/pfh.py
@@ -175,7 +175,9 @@ class PFH(object):
                 for p in p_list_copy:
                     pi = pc[p]
                     pj = pc[z]
-                    if np.arccos(np.dot(norm[p], pj - pi)) <= np.arccos(np.dot(norm[z], pi - pj)):
+
+                    norm_value = np.linalg.norm(pj - pi)
+                    if np.arccos(np.dot(norm[p], pj - pi)/norm_value) <= np.arccos(np.dot(norm[z], pi - pj)/norm_value):
                         ps = pi
                         pt = pj
                         ns = np.asarray(norm[p]).squeeze()


### PR DESCRIPTION
I was getting warnings in arccos calculation. Found this bug and referred to PCL implementation.

https://github.com/isl-org/Open3D/blob/14a6cbd8e706a39177475d08d449c5e238cc23e6/cpp/open3d/pipelines/registration/Feature.cpp#L52